### PR TITLE
Fix build warnings on newer glibc, log() being the math function that it...

### DIFF
--- a/c_src/debug.c
+++ b/c_src/debug.c
@@ -87,7 +87,7 @@ void debug(const char *fun, const char *fmt, ...) {
 
 }
 
-void log(int prefix, int suffix, const char *fun, const char *fmt, ...) {
+void log_message(int prefix, int suffix, const char *fun, const char *fmt, ...) {
 	va_list ap;
 
 	va_start(ap, fmt);

--- a/c_src/debug.h
+++ b/c_src/debug.h
@@ -34,9 +34,9 @@ extern int ei_tracelevel; // Hook into the ei library debug
 #define DEBUG(FMT) debug(__FUNCTION__, FMT)
 #define DEBUG_V(FMT, ...) debug(__FUNCTION__, FMT, __VA_ARGS__)
 
-#define LOG(FMT) log(1, 1, __FUNCTION__, FMT)
-#define LOG_V(FMT, ...) log(1, 1, __FUNCTION__, FMT, __VA_ARGS__)
+#define LOG(FMT) log_message(1, 1, __FUNCTION__, FMT)
+#define LOG_V(FMT, ...) log_message(1, 1, __FUNCTION__, FMT, __VA_ARGS__)
 
 void fatal_error(const char *file, int line, int e, const char *fmt, ...) __attribute__((format(printf, 4, 5)));
-void log(int prefix, int suffix, const char *fun, const char *fmt, ...) __attribute__((format(printf, 4, 5)));
+void log_message(int prefix, int suffix, const char *fun, const char *fmt, ...) __attribute__((format(printf, 4, 5)));
 void debug(const char *fun, const char *fmt, ...) __attribute__((format(printf, 2, 3)));

--- a/c_src/erld.c
+++ b/c_src/erld.c
@@ -288,13 +288,13 @@ int erld_main_loop(char *const argv[], int epmd_sock, int listen_sock, ei_cnode 
 					while ((q = strstr(p, "\r\n"))) {
 						/* q points to the end of a complete line */
 						*q = 0; /* null terminate this line */
-						log(at_eol, 1, "erl", "%s", p);
+						log_message(at_eol, 1, "erl", "%s", p);
 						at_eol = 1;
 						p = q + 2; /* 2 == length of separator, \r\n */
 					}
 					if (strlen(p)) {
 						/* there was an unterminated line at the end */
-						log(at_eol, 0, "erl", "%s", p);
+						log_message(at_eol, 0, "erl", "%s", p);
 						at_eol = 0;
 					}
 				}
@@ -409,7 +409,7 @@ int erld_main_loop(char *const argv[], int epmd_sock, int listen_sock, ei_cnode 
 						 * fragments of a long line can be written a piece at a time (with
 						 * each piece being flushed), but the copy written to the log file
 						 * has an EOL appended to maintain the log file format. */
-						log(1, 1, "stdout", "%s", ret_str);
+						log_message(1, 1, "stdout", "%s", ret_str);
 						if (!detached) {
 							printf("%s", ret_str);
 							fflush(stdout);


### PR DESCRIPTION
The log() function on my system ends up throwing some warnings on the newer glibc.  

For example..
cnode.c:231:8: warning: incompatible implicit declaration of built-in function ‘log’ [enabled by default]

If at some later date, warnings get defaulted to errors, the build will fail.   This is a simple function rename to prevent issues day, when someone will default gcc to this configuration.

Take it or leave the pull request, no big deal on my end.
