### PR TITLE
Remove obsolete src/

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = c_src src
+SUBDIRS = c_src

--- a/configure.in
+++ b/configure.in
@@ -28,7 +28,6 @@ AC_SUBST([ERLCFLAGS], [$erlcflags])
 AC_CONFIG_FILES([ \
 					  Makefile \
 					  c_src/Makefile \
-					  src/Makefile \
 					  ])
 
 AC_OUTPUT


### PR DESCRIPTION
Issue during bootstrap & configuration

```
$ ./bootstrap.sh
configure.in:15: installing `./compile'
configure.in:6: installing `./install-sh'
configure.in:6: installing `./missing'
c_src/Makefile.am: installing `./depcomp'
configure.in:28: required file `src/Makefile.in' not found
Makefile.am:1: required directory ./src does not exist

$ ./configure
--cut--
configure: creating ./config.status
config.status: error: cannot find input file: Makefile.in

$ make
make: *** No targets specified and no makefile found.  Stop.
```
